### PR TITLE
translate3to2: Ensure overwrite is unset if append is true

### DIFF
--- a/translate_3to2.go
+++ b/translate_3to2.go
@@ -310,15 +310,18 @@ func translateNode3to2(n types.Node, fss []string) old.Node {
 
 func translateFiles3to2(files []types.File, fss []string) (ret []old.File) {
 	for _, f := range files {
-		// Overwrite defaults to true in spec 2 and false in spec 3
-		if f.Node.Overwrite == nil {
-			f.Node.Overwrite = boolPStrict(false)
-		}
 		file := old.File{
 			Node: translateNode3to2(f.Node, fss),
 			FileEmbedded1: old.FileEmbedded1{
 				Mode: f.Mode,
 			},
+		}
+
+		// Overwrite defaults to false in spec 3 and true in spec 2; but
+		// we should omit it if append is specified as we want the "unset"
+		// default.
+		if f.Node.Overwrite == nil && len(f.FileEmbedded1.Append) == 0 {
+			file.Node.Overwrite = boolPStrict(false)
 		}
 
 		if f.FileEmbedded1.Contents.Source != nil {

--- a/translate_test.go
+++ b/translate_test.go
@@ -441,6 +441,19 @@ var (
 				{
 					Node: old2_2.Node{
 						Filesystem: "root",
+						Path:       "/etc/motd",
+					},
+					FileEmbedded1: old2_2.FileEmbedded1{
+						Append: true,
+						Mode:   intP(420),
+						Contents: old2_2.FileContents{
+							Source: "data:text/plain;base64,Zm9vCg==",
+						},
+					},
+				},
+				{
+					Node: old2_2.Node{
+						Filesystem: "root",
 						Path:       "/empty",
 						Overwrite:  boolPStrict(false),
 					},
@@ -584,6 +597,20 @@ var (
 								Verification: types.Verification{
 									Hash: &aSha512Hash,
 								},
+							},
+						},
+					},
+				},
+				{
+					Node: types.Node{
+						Path: "/etc/motd",
+						// Test default append with overwrite unset
+					},
+					FileEmbedded1: types.FileEmbedded1{
+						Mode: intP(420),
+						Append: []types.FileContents{
+							{
+								Source: strP("data:text/plain;base64,Zm9vCg=="),
 							},
 						},
 					},


### PR DESCRIPTION
I hit this while trying to port `cosa run` over to ign-converter.
It appends to an existing `/etc/motd` and relies on the "overwrite
is unset" behavior for append.  We don't want either `overwrite: true`
*or* `overwrite:false`, we want the "append to existing file"
semantic which is only triggered if `overwrite` is unset.