### PR TITLE
translate/v2*tov3*: Add RemoveDuplicateFilesAndUnits helper func

### DIFF
--- a/translate/v24tov31/v24tov31.go
+++ b/translate/v24tov31/v24tov31.go
@@ -473,3 +473,80 @@ func translateDirectories(dirs []old.Directory, m map[string]string) (ret []type
 	}
 	return
 }
+
+// RemoveDuplicateFilesAndUnits is a helper function that removes duplicated files/units from
+// spec v2 config, since neither spec v3 nor the translator function allow for duplicate file
+// entries in the config.
+// This functionality is not included in the Translate function and has some limitations, but
+// may be useful in cases where configuration has to be sanitized before translation.
+// For duplicates, it takes ordering into consideration by taking the file/unit contents from
+// the slice with the highest index value, which is assumed to be the latest revision.
+// Unit dropins are concat'ed, i.e. if no duplicate dropin of the same name exists it is added
+// to the list of dropins of the deduplicated unit definition.
+// The function will fail if a non-root filesystem is declared on any file.
+// It will also fail if file appendices are encountered.
+func RemoveDuplicateFilesAndUnits(cfg old.Config) (old.Config, error) {
+	files := cfg.Storage.Files
+	units := cfg.Systemd.Units
+
+	filePathMap := map[string]bool{}
+	var outFiles []old.File
+	// range from highest to lowest index
+	for i := len(files) - 1; i >= 0; i-- {
+		if files[i].Filesystem != "root" {
+			return old.Config{}, errors.New("cannot dedupe set of files on non-root filesystem")
+		}
+		if files[i].Append == true {
+			return old.Config{}, errors.New("cannot dedupe set of files that contains appendices")
+		}
+		path := files[i].Path
+		if _, isDup := filePathMap[path]; isDup {
+			// dupes are ignored
+			continue
+		}
+		// append unique file
+		outFiles = append(outFiles, files[i])
+		filePathMap[path] = true
+	}
+
+	unitNameMap := map[string]bool{}
+	var outUnits []old.Unit
+	// range from highest to lowest index
+	for i := len(units) - 1; i >= 0; i-- {
+		unitName := units[i].Name
+		if _, isDup := unitNameMap[unitName]; isDup {
+			// this is a duplicated unit by name
+			if len(units[i].Dropins) > 0 {
+				for j := range outUnits {
+					if outUnits[j].Name == unitName {
+						// outUnits[j] is the highest priority entry with this unit name
+						// now loop over the new unit's dropins and append it if the name
+						// isn't duplicated in the existing unit's dropins
+						for _, newDropin := range units[i].Dropins {
+							hasExistingDropin := false
+							for _, existingDropin := range outUnits[j].Dropins {
+								if existingDropin.Name == newDropin.Name {
+									hasExistingDropin = true
+									break
+								}
+							}
+							if !hasExistingDropin {
+								outUnits[j].Dropins = append(outUnits[j].Dropins, newDropin)
+							}
+						}
+					}
+				}
+			}
+		} else {
+			// append unique unit
+			outUnits = append(outUnits, units[i])
+			unitNameMap[unitName] = true
+		}
+	}
+
+	// outFiles and outUnits should now have all duplication removed
+	cfg.Storage.Files = outFiles
+	cfg.Systemd.Units = outUnits
+
+	return cfg, nil
+}

--- a/translate_test.go
+++ b/translate_test.go
@@ -1280,3 +1280,221 @@ func TestTranslate3_1to2_4(t *testing.T) {
 	}
 	assert.Equal(t, exhaustiveConfig2_4, res)
 }
+
+func TestRemoveDuplicateFilesAndUnits2_3(t *testing.T) {
+	mode := 420
+	testDataOld := "data:,old"
+	testDataNew := "data:,new"
+	testIgn2Config := types2_3.Config{}
+
+	// file test, add a duplicate file and see if the newest one is preserved
+	fileOld := types2_3.File{
+		Node: types2_3.Node{
+			Filesystem: "root", Path: "/etc/testfileconfig",
+		},
+		FileEmbedded1: types2_3.FileEmbedded1{
+			Contents: types2_3.FileContents{
+				Source: testDataOld,
+			},
+			Mode: &mode,
+		},
+	}
+	testIgn2Config.Storage.Files = append(testIgn2Config.Storage.Files, fileOld)
+
+	fileNew := types2_3.File{
+		Node: types2_3.Node{
+			Filesystem: "root", Path: "/etc/testfileconfig",
+		},
+		FileEmbedded1: types2_3.FileEmbedded1{
+			Contents: types2_3.FileContents{
+				Source: testDataNew,
+			},
+			Mode: &mode,
+		},
+	}
+	testIgn2Config.Storage.Files = append(testIgn2Config.Storage.Files, fileNew)
+
+	// unit test, add three units and three dropins with the same name as follows:
+	// unitOne:
+	//    contents: old
+	//    dropin:
+	//        name: one
+	//        contents: old
+	// unitTwo:
+	//    dropin:
+	//        name: one
+	//        contents: new
+	// unitThree:
+	//    contents: new
+	//    dropin:
+	//        name: two
+	//        contents: new
+	// Which should result in:
+	// unitFinal:
+	//    contents: new
+	//    dropin:
+	//      - name: one
+	//        contents: new
+	//      - name: two
+	//        contents: new
+	//
+	unitName := "testUnit"
+	dropinNameOne := "one"
+	dropinNameTwo := "two"
+	dropinOne := types2_3.SystemdDropin{
+		Contents: testDataOld,
+		Name:     dropinNameOne,
+	}
+	dropinTwo := types2_3.SystemdDropin{
+		Contents: testDataNew,
+		Name:     dropinNameOne,
+	}
+	dropinThree := types2_3.SystemdDropin{
+		Contents: testDataNew,
+		Name:     dropinNameTwo,
+	}
+
+	unitOne := types2_3.Unit{
+		Contents: testDataOld,
+		Name:     unitName,
+	}
+	unitOne.Dropins = append(unitOne.Dropins, dropinOne)
+	testIgn2Config.Systemd.Units = append(testIgn2Config.Systemd.Units, unitOne)
+
+	unitTwo := types2_3.Unit{
+		Name: unitName,
+	}
+	unitTwo.Dropins = append(unitTwo.Dropins, dropinTwo)
+	testIgn2Config.Systemd.Units = append(testIgn2Config.Systemd.Units, unitTwo)
+
+	unitThree := types2_3.Unit{
+		Contents: testDataNew,
+		Name:     unitName,
+	}
+	unitThree.Dropins = append(unitThree.Dropins, dropinThree)
+	testIgn2Config.Systemd.Units = append(testIgn2Config.Systemd.Units, unitThree)
+
+	convertedIgn2Config, err := v23tov30.RemoveDuplicateFilesAndUnits(testIgn2Config)
+	assert.NoError(t, err)
+
+	expectedIgn2Config := types2_3.Config{}
+	expectedIgn2Config.Storage.Files = append(expectedIgn2Config.Storage.Files, fileNew)
+	unitExpected := types2_3.Unit{
+		Contents: testDataNew,
+		Name:     unitName,
+	}
+	unitExpected.Dropins = append(unitExpected.Dropins, dropinThree)
+	unitExpected.Dropins = append(unitExpected.Dropins, dropinTwo)
+	expectedIgn2Config.Systemd.Units = append(expectedIgn2Config.Systemd.Units, unitExpected)
+
+	assert.Equal(t, expectedIgn2Config, convertedIgn2Config)
+}
+
+func TestRemoveDuplicateFilesAndUnits2_4(t *testing.T) {
+	mode := 420
+	testDataOld := "data:,old"
+	testDataNew := "data:,new"
+	testIgn2Config := types2_4.Config{}
+
+	// file test, add a duplicate file and see if the newest one is preserved
+	fileOld := types2_4.File{
+		Node: types2_4.Node{
+			Filesystem: "root", Path: "/etc/testfileconfig",
+		},
+		FileEmbedded1: types2_4.FileEmbedded1{
+			Contents: types2_4.FileContents{
+				Source: testDataOld,
+			},
+			Mode: &mode,
+		},
+	}
+	testIgn2Config.Storage.Files = append(testIgn2Config.Storage.Files, fileOld)
+
+	fileNew := types2_4.File{
+		Node: types2_4.Node{
+			Filesystem: "root", Path: "/etc/testfileconfig",
+		},
+		FileEmbedded1: types2_4.FileEmbedded1{
+			Contents: types2_4.FileContents{
+				Source: testDataNew,
+			},
+			Mode: &mode,
+		},
+	}
+	testIgn2Config.Storage.Files = append(testIgn2Config.Storage.Files, fileNew)
+
+	// unit test, add three units and three dropins with the same name as follows:
+	// unitOne:
+	//    contents: old
+	//    dropin:
+	//        name: one
+	//        contents: old
+	// unitTwo:
+	//    dropin:
+	//        name: one
+	//        contents: new
+	// unitThree:
+	//    contents: new
+	//    dropin:
+	//        name: two
+	//        contents: new
+	// Which should result in:
+	// unitFinal:
+	//    contents: new
+	//    dropin:
+	//      - name: one
+	//        contents: new
+	//      - name: two
+	//        contents: new
+	//
+	unitName := "testUnit"
+	dropinNameOne := "one"
+	dropinNameTwo := "two"
+	dropinOne := types2_4.SystemdDropin{
+		Contents: testDataOld,
+		Name:     dropinNameOne,
+	}
+	dropinTwo := types2_4.SystemdDropin{
+		Contents: testDataNew,
+		Name:     dropinNameOne,
+	}
+	dropinThree := types2_4.SystemdDropin{
+		Contents: testDataNew,
+		Name:     dropinNameTwo,
+	}
+
+	unitOne := types2_4.Unit{
+		Contents: testDataOld,
+		Name:     unitName,
+	}
+	unitOne.Dropins = append(unitOne.Dropins, dropinOne)
+	testIgn2Config.Systemd.Units = append(testIgn2Config.Systemd.Units, unitOne)
+
+	unitTwo := types2_4.Unit{
+		Name: unitName,
+	}
+	unitTwo.Dropins = append(unitTwo.Dropins, dropinTwo)
+	testIgn2Config.Systemd.Units = append(testIgn2Config.Systemd.Units, unitTwo)
+
+	unitThree := types2_4.Unit{
+		Contents: testDataNew,
+		Name:     unitName,
+	}
+	unitThree.Dropins = append(unitThree.Dropins, dropinThree)
+	testIgn2Config.Systemd.Units = append(testIgn2Config.Systemd.Units, unitThree)
+
+	convertedIgn2Config, err := v24tov31.RemoveDuplicateFilesAndUnits(testIgn2Config)
+	assert.NoError(t, err)
+
+	expectedIgn2Config := types2_4.Config{}
+	expectedIgn2Config.Storage.Files = append(expectedIgn2Config.Storage.Files, fileNew)
+	unitExpected := types2_4.Unit{
+		Contents: testDataNew,
+		Name:     unitName,
+	}
+	unitExpected.Dropins = append(unitExpected.Dropins, dropinThree)
+	unitExpected.Dropins = append(unitExpected.Dropins, dropinTwo)
+	expectedIgn2Config.Systemd.Units = append(expectedIgn2Config.Systemd.Units, unitExpected)
+
+	assert.Equal(t, expectedIgn2Config, convertedIgn2Config)
+}


### PR DESCRIPTION
This was originally written by Jerry Zhang for inclusion in the MCO [1].
Adding it here as the deduplication step often times has to be performed
in preparation of translation when dealing with v2 config in order to
sanitize it.

RemoveDuplicateFilesAndUnits is a helper function that removes duplicated files/units from
spec v2 config, since neither spec v3 nor the translator function allow for duplicate file
entries in the config.
This functionality is not included in the Translate function, but may be useful in cases
where configuration has to be sanitized before translation.
For duplicates, it takes ordering into consideration by taking the file/unit contents from
the slice with the highest index value, which is assumed to be the latest revision.
Multiple filesystems are not considered, it is assumed there is only one.
File appendices are not considered.
Unit dropins are concat'ed, i.e. appended if no duplicate dropin of the same name exists.

[1] https://github.com/openshift/machine-config-operator/commit/12668c044cbc5d4d7c2e3c90cd6ab13fa7d6f49d

Co-authored-by: Yu Qi Zhang <jerzhang@redhat.com>

/cc @yuqi-zhang 