### PR TITLE
translate/v2*tov3*: De-duplicate spec v2 passwdUsers

### DIFF
--- a/translate/v23tov30/v23tov30.go
+++ b/translate/v23tov30/v23tov30.go
@@ -448,9 +448,9 @@ func translateDirectories(dirs []old.Directory, m map[string]string) (ret []type
 	return
 }
 
-// RemoveDuplicateFilesAndUnits is a helper function that removes duplicated files/units from
-// spec v2 config, since neither spec v3 nor the translator function allow for duplicate file
-// entries in the config.
+// RemoveDuplicateFilesUnitsUsers is a helper function that removes duplicated files/units/users
+// from spec v2 config, since neither spec v3 nor the translator function allow for duplicate
+// file entries in the config.
 // This functionality is not included in the Translate function and has some limitations, but
 // may be useful in cases where configuration has to be sanitized before translation.
 // For duplicates, it takes ordering into consideration by taking the file/unit contents from
@@ -459,9 +459,10 @@ func translateDirectories(dirs []old.Directory, m map[string]string) (ret []type
 // to the list of dropins of the deduplicated unit definition.
 // The function will fail if a non-root filesystem is declared on any file.
 // It will also fail if file appendices are encountered.
-func RemoveDuplicateFilesAndUnits(cfg old.Config) (old.Config, error) {
+func RemoveDuplicateFilesUnitsUsers(cfg old.Config) (old.Config, error) {
 	files := cfg.Storage.Files
 	units := cfg.Systemd.Units
+	users := cfg.Passwd.Users
 
 	filePathMap := map[string]bool{}
 	var outFiles []old.File
@@ -518,9 +519,34 @@ func RemoveDuplicateFilesAndUnits(cfg old.Config) (old.Config, error) {
 		}
 	}
 
-	// outFiles and outUnits should now have all duplication removed
+	// Concat sshkey sections into the newest passwdUser in the list
+	// Only the SSHAuthorizedKeys of a duplicate user are considered,
+	// all other fields are ignored.
+	userNameMap := map[string]bool{}
+	var outUsers []old.PasswdUser
+	// range from highest to lowest index
+	for i := len(users) - 1; i >= 0; i-- {
+		userName := users[i].Name
+		if _, isDup := userNameMap[userName]; isDup {
+			// this is a duplicated user by name, append keys to existing user
+			for j := range outUsers {
+				if outUsers[j].Name == userName {
+					for _, newKey := range users[i].SSHAuthorizedKeys {
+						outUsers[j].SSHAuthorizedKeys = append(outUsers[j].SSHAuthorizedKeys, newKey)
+					}
+				}
+			}
+		} else {
+			// append unique users
+			outUsers = append(outUsers, users[i])
+			userNameMap[userName] = true
+		}
+	}
+
+	// outFiles, outUnits, and outUsers should now have all duplication removed
 	cfg.Storage.Files = outFiles
 	cfg.Systemd.Units = outUnits
+	cfg.Passwd.Users = outUsers
 
 	return cfg, nil
 }

--- a/translate_test.go
+++ b/translate_test.go
@@ -1708,7 +1708,7 @@ func TestTranslate3_2to3_1(t *testing.T) {
 	assert.Equal(t, nonexhaustiveConfig3_1, res)
 }
 
-func TestRemoveDuplicateFilesAndUnits2_3(t *testing.T) {
+func TestRemoveDuplicateFilesUnitsUsers2_3(t *testing.T) {
 	mode := 420
 	testDataOld := "data:,old"
 	testDataNew := "data:,new"
@@ -1801,7 +1801,30 @@ func TestRemoveDuplicateFilesAndUnits2_3(t *testing.T) {
 	unitThree.Dropins = append(unitThree.Dropins, dropinThree)
 	testIgn2Config.Systemd.Units = append(testIgn2Config.Systemd.Units, unitThree)
 
-	convertedIgn2Config, err := v23tov30.RemoveDuplicateFilesAndUnits(testIgn2Config)
+	// user test, add a duplicate user and see if it is deduplicated but ssh keys from both are preserved
+	userName := "testUser"
+	userOne := types2_3.PasswdUser{
+		Name: userName,
+		SSHAuthorizedKeys: []types2_3.SSHAuthorizedKey{
+			"one",
+			"two",
+		},
+	}
+	userTwo := types2_3.PasswdUser{
+		Name: userName,
+		SSHAuthorizedKeys: []types2_3.SSHAuthorizedKey{
+			"three",
+		},
+	}
+	userThree := types2_3.PasswdUser{
+		Name: "userThree",
+		SSHAuthorizedKeys: []types2_3.SSHAuthorizedKey{
+			"four",
+		},
+	}
+	testIgn2Config.Passwd.Users = append(testIgn2Config.Passwd.Users, userOne, userTwo, userThree)
+
+	convertedIgn2Config, err := v23tov30.RemoveDuplicateFilesUnitsUsers(testIgn2Config)
 	assert.NoError(t, err)
 
 	expectedIgn2Config := types2_3.Config{}
@@ -1813,11 +1836,20 @@ func TestRemoveDuplicateFilesAndUnits2_3(t *testing.T) {
 	unitExpected.Dropins = append(unitExpected.Dropins, dropinThree)
 	unitExpected.Dropins = append(unitExpected.Dropins, dropinTwo)
 	expectedIgn2Config.Systemd.Units = append(expectedIgn2Config.Systemd.Units, unitExpected)
+	expectedMergedUser := types2_3.PasswdUser{
+		Name: userName,
+		SSHAuthorizedKeys: []types2_3.SSHAuthorizedKey{
+			"three",
+			"one",
+			"two",
+		},
+	}
+	expectedIgn2Config.Passwd.Users = append(expectedIgn2Config.Passwd.Users, userThree, expectedMergedUser)
 
 	assert.Equal(t, expectedIgn2Config, convertedIgn2Config)
 }
 
-func TestRemoveDuplicateFilesAndUnits2_4(t *testing.T) {
+func TestRemoveDuplicateFilesUnitsUsers2_4(t *testing.T) {
 	mode := 420
 	testDataOld := "data:,old"
 	testDataNew := "data:,new"
@@ -1910,7 +1942,30 @@ func TestRemoveDuplicateFilesAndUnits2_4(t *testing.T) {
 	unitThree.Dropins = append(unitThree.Dropins, dropinThree)
 	testIgn2Config.Systemd.Units = append(testIgn2Config.Systemd.Units, unitThree)
 
-	convertedIgn2Config, err := v24tov31.RemoveDuplicateFilesAndUnits(testIgn2Config)
+	// user test, add a duplicate user and see if it is deduplicated but ssh keys from both are preserved
+	userName := "testUser"
+	userOne := types2_4.PasswdUser{
+		Name: userName,
+		SSHAuthorizedKeys: []types2_4.SSHAuthorizedKey{
+			"one",
+			"two",
+		},
+	}
+	userTwo := types2_4.PasswdUser{
+		Name: userName,
+		SSHAuthorizedKeys: []types2_4.SSHAuthorizedKey{
+			"three",
+		},
+	}
+	userThree := types2_4.PasswdUser{
+		Name: "userThree",
+		SSHAuthorizedKeys: []types2_4.SSHAuthorizedKey{
+			"four",
+		},
+	}
+	testIgn2Config.Passwd.Users = append(testIgn2Config.Passwd.Users, userOne, userTwo, userThree)
+
+	convertedIgn2Config, err := v24tov31.RemoveDuplicateFilesUnitsUsers(testIgn2Config)
 	assert.NoError(t, err)
 
 	expectedIgn2Config := types2_4.Config{}
@@ -1922,6 +1977,14 @@ func TestRemoveDuplicateFilesAndUnits2_4(t *testing.T) {
 	unitExpected.Dropins = append(unitExpected.Dropins, dropinThree)
 	unitExpected.Dropins = append(unitExpected.Dropins, dropinTwo)
 	expectedIgn2Config.Systemd.Units = append(expectedIgn2Config.Systemd.Units, unitExpected)
-
+	expectedMergedUser := types2_4.PasswdUser{
+		Name: userName,
+		SSHAuthorizedKeys: []types2_4.SSHAuthorizedKey{
+			"three",
+			"one",
+			"two",
+		},
+	}
+	expectedIgn2Config.Passwd.Users = append(expectedIgn2Config.Passwd.Users, userThree, expectedMergedUser)
 	assert.Equal(t, expectedIgn2Config, convertedIgn2Config)
 }


### PR DESCRIPTION
Similar functionality has been added to the MCO [1].
Adding deduplication for users here to keep implementations equivalent.

[1] openshift/machine-config-operator@ccb8d10

/cc @yuqi-zhang 
If there are no objections, I'll also open a PR to MCO to replace the function there with the one from this repo