### PR TITLE
translate: support deprecated `create` filesystem object 

### DIFF
--- a/translate/v24tov31/v24tov31.go
+++ b/translate/v24tov31/v24tov31.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"path"
 	"reflect"
+	"strings"
 
 	old "github.com/coreos/ignition/config/v2_4/types"
 	oldValidate "github.com/coreos/ignition/config/validate"
@@ -372,12 +373,50 @@ func translateFilesystems(fss []old.Filesystem, m map[string]string) (ret []type
 		if f.Mount == nil {
 			f.Mount = &old.Mount{}
 		}
+
+		wipe := util.BoolP(f.Mount.WipeFilesystem)
+		label := f.Mount.Label
+		uuid := f.Mount.UUID
+
+		// If `wipe` is set to `false` but we have a `"create": {...}` section, we try
+		// to convert it.
+		if wipe == nil && f.Mount.Create != nil {
+			wipe = util.BoolP(f.Mount.Create.Force)
+
+			for _, opt := range f.Mount.Create.Options {
+				o := string(opt)
+				// Example: `--label=ROOT` or `-L ROOT`
+				if strings.Contains(o, "label") || strings.Contains(o, "-L") {
+					l := strings.SplitN(o, "=", 2)
+					// In order to avoid ignition to panic, we continue if the
+					// size is not expected
+					if len(l) < 2 {
+						continue
+					}
+
+					label = &l[1]
+				}
+
+				// Example `-m uuid=1234` or `-U 1234`
+				if strings.Contains(o, "uuid") || strings.Contains(o, "-U") {
+					u := strings.SplitN(o, "=", 2)
+					// In order to avoid ignition to panic, we continue if the
+					// size is not expected
+					if len(u) < 2 {
+						continue
+					}
+
+					uuid = &u[1]
+				}
+			}
+		}
+
 		ret = append(ret, types.Filesystem{
 			Device:         f.Mount.Device,
 			Format:         util.StrP(f.Mount.Format),
-			WipeFilesystem: util.BoolP(f.Mount.WipeFilesystem),
-			Label:          f.Mount.Label,
-			UUID:           f.Mount.UUID,
+			WipeFilesystem: wipe,
+			Label:          label,
+			UUID:           uuid,
 			Options:        translateFilesystemOptions(f.Mount.Options),
 			Path:           util.StrP(m[f.Name]),
 		})

--- a/translate_test.go
+++ b/translate_test.go
@@ -15,6 +15,7 @@
 package ignconverter
 
 import (
+	"fmt"
 	"testing"
 
 	types2_2 "github.com/coreos/ignition/config/v2_2/types"
@@ -193,6 +194,356 @@ var (
 						},
 					},
 					LinkEmbedded1: types2_3.LinkEmbedded1{
+						Hard:   false,
+						Target: "/foobar",
+					},
+				},
+			},
+		},
+	}
+
+	wrongDeprecatedConfig2_4 = types2_4.Config{
+		Ignition: types2_4.Ignition{
+			Version: "2.4.0",
+			Config: types2_4.IgnitionConfig{
+				Append: []types2_4.ConfigReference{
+					{
+						Source: "https://example.com",
+						Verification: types2_4.Verification{
+							Hash: &aSha512Hash,
+						},
+					},
+				},
+				Replace: &types2_4.ConfigReference{
+					Source: "https://example.com",
+					Verification: types2_4.Verification{
+						Hash: &aSha512Hash,
+					},
+				},
+			},
+			Timeouts: types2_4.Timeouts{
+				HTTPResponseHeaders: util.IntP(5),
+				HTTPTotal:           util.IntP(10),
+			},
+			Security: types2_4.Security{
+				TLS: types2_4.TLS{
+					CertificateAuthorities: []types2_4.CaReference{
+						{
+							Source: "https://example.com",
+							Verification: types2_4.Verification{
+								Hash: &aSha512Hash,
+							},
+						},
+					},
+				},
+			},
+			Proxy: types2_4.Proxy{
+				HTTPProxy:  "https://proxy.example.net/",
+				HTTPSProxy: "https://secure.proxy.example.net/",
+				NoProxy: []types2_4.NoProxyItem{
+					"www.example.net",
+					"www.example2.net",
+				},
+			},
+		},
+		Storage: types2_4.Storage{
+			Disks: []types2_4.Disk{
+				{
+					Device:    "/dev/sda",
+					WipeTable: true,
+					Partitions: []types2_4.Partition{
+						{
+							Label:              util.StrP("var"),
+							Number:             1,
+							SizeMiB:            util.IntP(5000),
+							StartMiB:           util.IntP(2048),
+							TypeGUID:           aUUID,
+							GUID:               aUUID,
+							WipePartitionEntry: true,
+							ShouldExist:        util.BoolP(true),
+						},
+					},
+				},
+			},
+			Raid: []types2_4.Raid{
+				{
+					Name:    "array",
+					Level:   "raid10",
+					Devices: []types2_4.Device{"/dev/sdb", "/dev/sdc"},
+					Spares:  1,
+					Options: []types2_4.RaidOption{"foobar"},
+				},
+			},
+			Filesystems: []types2_4.Filesystem{
+				{
+					Name: "/var",
+					Mount: &types2_4.Mount{
+						Device: "/dev/disk/by-partlabel/var",
+						Format: "xfs",
+						Create: &types2_4.Create{
+							Force: true,
+							Options: []types2_4.CreateOption{
+								"--labl=ROOT",
+								types2_4.CreateOption(fmt.Sprintf("--uuid=%s", aUUID)),
+							},
+						},
+					},
+				},
+			},
+			Files: []types2_4.File{
+				{
+					Node: types2_4.Node{
+						Filesystem: "/var",
+						Path:       "/varfile",
+						Overwrite:  util.BoolPStrict(false),
+						User: &types2_4.NodeUser{
+							ID: util.IntP(1000),
+						},
+						Group: &types2_4.NodeGroup{
+							Name: "groupname",
+						},
+					},
+					FileEmbedded1: types2_4.FileEmbedded1{
+						Append: true,
+						Mode:   util.IntP(420),
+						Contents: types2_4.FileContents{
+							Compression: "gzip",
+							Source:      "https://example.com",
+							Verification: types2_4.Verification{
+								Hash: &aSha512Hash,
+							},
+							HTTPHeaders: types2_4.HTTPHeaders{
+								types2_4.HTTPHeader{
+									Name:  "Authorization",
+									Value: "Basic YWxhZGRpbjpvcGVuc2VzYW1l",
+								},
+								types2_4.HTTPHeader{
+									Name:  "User-Agent",
+									Value: "Mozilla/5.0 (compatible; MSIE 6.0; Windows NT 5.1)",
+								},
+							},
+						},
+					},
+				},
+				{
+					Node: types2_4.Node{
+						Filesystem: "root",
+						Path:       "/empty",
+						Overwrite:  util.BoolPStrict(false),
+					},
+					FileEmbedded1: types2_4.FileEmbedded1{
+						Mode: util.IntP(420),
+					},
+				},
+			},
+			Directories: []types2_4.Directory{
+				{
+					Node: types2_4.Node{
+						Filesystem: "root",
+						Path:       "/rootdir",
+						Overwrite:  util.BoolP(true),
+						User: &types2_4.NodeUser{
+							ID: util.IntP(1000),
+						},
+						Group: &types2_4.NodeGroup{
+							Name: "groupname",
+						},
+					},
+					DirectoryEmbedded1: types2_4.DirectoryEmbedded1{
+						Mode: util.IntP(420),
+					},
+				},
+			},
+			Links: []types2_4.Link{
+				{
+					Node: types2_4.Node{
+						Filesystem: "root",
+						Path:       "/rootlink",
+						Overwrite:  util.BoolP(true),
+						User: &types2_4.NodeUser{
+							ID: util.IntP(1000),
+						},
+						Group: &types2_4.NodeGroup{
+							Name: "groupname",
+						},
+					},
+					LinkEmbedded1: types2_4.LinkEmbedded1{
+						Hard:   false,
+						Target: "/foobar",
+					},
+				},
+			},
+		},
+	}
+
+	deprecatedConfig2_4 = types2_4.Config{
+		Ignition: types2_4.Ignition{
+			Version: "2.4.0",
+			Config: types2_4.IgnitionConfig{
+				Append: []types2_4.ConfigReference{
+					{
+						Source: "https://example.com",
+						Verification: types2_4.Verification{
+							Hash: &aSha512Hash,
+						},
+					},
+				},
+				Replace: &types2_4.ConfigReference{
+					Source: "https://example.com",
+					Verification: types2_4.Verification{
+						Hash: &aSha512Hash,
+					},
+				},
+			},
+			Timeouts: types2_4.Timeouts{
+				HTTPResponseHeaders: util.IntP(5),
+				HTTPTotal:           util.IntP(10),
+			},
+			Security: types2_4.Security{
+				TLS: types2_4.TLS{
+					CertificateAuthorities: []types2_4.CaReference{
+						{
+							Source: "https://example.com",
+							Verification: types2_4.Verification{
+								Hash: &aSha512Hash,
+							},
+						},
+					},
+				},
+			},
+			Proxy: types2_4.Proxy{
+				HTTPProxy:  "https://proxy.example.net/",
+				HTTPSProxy: "https://secure.proxy.example.net/",
+				NoProxy: []types2_4.NoProxyItem{
+					"www.example.net",
+					"www.example2.net",
+				},
+			},
+		},
+		Storage: types2_4.Storage{
+			Disks: []types2_4.Disk{
+				{
+					Device:    "/dev/sda",
+					WipeTable: true,
+					Partitions: []types2_4.Partition{
+						{
+							Label:              util.StrP("var"),
+							Number:             1,
+							SizeMiB:            util.IntP(5000),
+							StartMiB:           util.IntP(2048),
+							TypeGUID:           aUUID,
+							GUID:               aUUID,
+							WipePartitionEntry: true,
+							ShouldExist:        util.BoolP(true),
+						},
+					},
+				},
+			},
+			Raid: []types2_4.Raid{
+				{
+					Name:    "array",
+					Level:   "raid10",
+					Devices: []types2_4.Device{"/dev/sdb", "/dev/sdc"},
+					Spares:  1,
+					Options: []types2_4.RaidOption{"foobar"},
+				},
+			},
+			Filesystems: []types2_4.Filesystem{
+				{
+					Name: "/var",
+					Mount: &types2_4.Mount{
+						Device: "/dev/disk/by-partlabel/var",
+						Format: "xfs",
+						Label:  util.StrP("var"),
+						UUID:   &aUUID,
+						Create: &types2_4.Create{
+							Force: true,
+							Options: []types2_4.CreateOption{
+								"--label=var",
+								types2_4.CreateOption(fmt.Sprintf("--uuid=%s", aUUID)),
+							},
+						},
+					},
+				},
+			},
+			Files: []types2_4.File{
+				{
+					Node: types2_4.Node{
+						Filesystem: "/var",
+						Path:       "/varfile",
+						Overwrite:  util.BoolPStrict(false),
+						User: &types2_4.NodeUser{
+							ID: util.IntP(1000),
+						},
+						Group: &types2_4.NodeGroup{
+							Name: "groupname",
+						},
+					},
+					FileEmbedded1: types2_4.FileEmbedded1{
+						Append: true,
+						Mode:   util.IntP(420),
+						Contents: types2_4.FileContents{
+							Compression: "gzip",
+							Source:      "https://example.com",
+							Verification: types2_4.Verification{
+								Hash: &aSha512Hash,
+							},
+							HTTPHeaders: types2_4.HTTPHeaders{
+								types2_4.HTTPHeader{
+									Name:  "Authorization",
+									Value: "Basic YWxhZGRpbjpvcGVuc2VzYW1l",
+								},
+								types2_4.HTTPHeader{
+									Name:  "User-Agent",
+									Value: "Mozilla/5.0 (compatible; MSIE 6.0; Windows NT 5.1)",
+								},
+							},
+						},
+					},
+				},
+				{
+					Node: types2_4.Node{
+						Filesystem: "root",
+						Path:       "/empty",
+						Overwrite:  util.BoolPStrict(false),
+					},
+					FileEmbedded1: types2_4.FileEmbedded1{
+						Mode: util.IntP(420),
+					},
+				},
+			},
+			Directories: []types2_4.Directory{
+				{
+					Node: types2_4.Node{
+						Filesystem: "root",
+						Path:       "/rootdir",
+						Overwrite:  util.BoolP(true),
+						User: &types2_4.NodeUser{
+							ID: util.IntP(1000),
+						},
+						Group: &types2_4.NodeGroup{
+							Name: "groupname",
+						},
+					},
+					DirectoryEmbedded1: types2_4.DirectoryEmbedded1{
+						Mode: util.IntP(420),
+					},
+				},
+			},
+			Links: []types2_4.Link{
+				{
+					Node: types2_4.Node{
+						Filesystem: "root",
+						Path:       "/rootlink",
+						Overwrite:  util.BoolP(true),
+						User: &types2_4.NodeUser{
+							ID: util.IntP(1000),
+						},
+						Group: &types2_4.NodeGroup{
+							Name: "groupname",
+						},
+					},
+					LinkEmbedded1: types2_4.LinkEmbedded1{
 						Hard:   false,
 						Target: "/foobar",
 					},
@@ -843,6 +1194,341 @@ var (
 						},
 					},
 					LinkEmbedded1: types3_0.LinkEmbedded1{
+						Hard:   util.BoolP(false),
+						Target: "/foobar",
+					},
+				},
+			},
+		},
+	}
+
+	config3_1WithNoFSOptions = types3_1.Config{
+		Ignition: types3_1.Ignition{
+			Version: "3.1.0",
+			Config: types3_1.IgnitionConfig{
+				Merge: []types3_1.Resource{
+					{
+						Source: util.StrP("https://example.com"),
+						Verification: types3_1.Verification{
+							Hash: &aSha512Hash,
+						},
+					},
+				},
+				Replace: types3_1.Resource{
+					Source: util.StrP("https://example.com"),
+					Verification: types3_1.Verification{
+						Hash: &aSha512Hash,
+					},
+				},
+			},
+			Timeouts: types3_1.Timeouts{
+				HTTPResponseHeaders: util.IntP(5),
+				HTTPTotal:           util.IntP(10),
+			},
+			Security: types3_1.Security{
+				TLS: types3_1.TLS{
+					CertificateAuthorities: []types3_1.Resource{
+						{
+							Source: util.StrP("https://example.com"),
+							Verification: types3_1.Verification{
+								Hash: &aSha512Hash,
+							},
+						},
+					},
+				},
+			},
+			Proxy: types3_1.Proxy{
+				HTTPProxy:  util.StrP("https://proxy.example.net/"),
+				HTTPSProxy: util.StrP("https://secure.proxy.example.net/"),
+				NoProxy: []types3_1.NoProxyItem{
+					"www.example.net",
+					"www.example2.net",
+				},
+			},
+		},
+		Storage: types3_1.Storage{
+			Disks: []types3_1.Disk{
+				{
+					Device:    "/dev/sda",
+					WipeTable: util.BoolP(true),
+					Partitions: []types3_1.Partition{
+						{
+							Label:              util.StrP("var"),
+							Number:             1,
+							SizeMiB:            util.IntP(5000),
+							StartMiB:           util.IntP(2048),
+							TypeGUID:           &aUUID,
+							GUID:               &aUUID,
+							WipePartitionEntry: util.BoolP(true),
+							ShouldExist:        util.BoolP(true),
+						},
+					},
+				},
+			},
+			Raid: []types3_1.Raid{
+				{
+					Name:    "array",
+					Level:   "raid10",
+					Devices: []types3_1.Device{"/dev/sdb", "/dev/sdc"},
+					Spares:  util.IntP(1),
+					Options: []types3_1.RaidOption{"foobar"},
+				},
+			},
+			Filesystems: []types3_1.Filesystem{
+				{
+					Path:           util.StrP("/var"),
+					Device:         "/dev/disk/by-partlabel/var",
+					Format:         util.StrP("xfs"),
+					WipeFilesystem: util.BoolP(true),
+					Label:          util.StrP("var"),
+					UUID:           &aUUID,
+				},
+			},
+			Files: []types3_1.File{
+				{
+					Node: types3_1.Node{
+						Path:      "/var/varfile",
+						Overwrite: util.BoolPStrict(false),
+						User: types3_1.NodeUser{
+							ID: util.IntP(1000),
+						},
+						Group: types3_1.NodeGroup{
+							Name: util.StrP("groupname"),
+						},
+					},
+					FileEmbedded1: types3_1.FileEmbedded1{
+						Mode: util.IntP(420),
+						Append: []types3_1.Resource{
+							{
+								Compression: util.StrP("gzip"),
+								Source:      util.StrP("https://example.com"),
+								Verification: types3_1.Verification{
+									Hash: &aSha512Hash,
+								},
+								HTTPHeaders: types3_1.HTTPHeaders{
+									types3_1.HTTPHeader{
+										Name:  "Authorization",
+										Value: util.StrP("Basic YWxhZGRpbjpvcGVuc2VzYW1l"),
+									},
+									types3_1.HTTPHeader{
+										Name:  "User-Agent",
+										Value: util.StrP("Mozilla/5.0 (compatible; MSIE 6.0; Windows NT 5.1)"),
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					Node: types3_1.Node{
+						Path:      "/empty",
+						Overwrite: util.BoolPStrict(false),
+					},
+					FileEmbedded1: types3_1.FileEmbedded1{
+						Mode: util.IntP(420),
+						Contents: types3_1.Resource{
+							Source: util.StrPStrict(""),
+						},
+					},
+				},
+			},
+			Directories: []types3_1.Directory{
+				{
+					Node: types3_1.Node{
+						Path:      "/rootdir",
+						Overwrite: util.BoolP(true),
+						User: types3_1.NodeUser{
+							ID: util.IntP(1000),
+						},
+						Group: types3_1.NodeGroup{
+							Name: util.StrP("groupname"),
+						},
+					},
+					DirectoryEmbedded1: types3_1.DirectoryEmbedded1{
+						Mode: util.IntP(420),
+					},
+				},
+			},
+			Links: []types3_1.Link{
+				{
+					Node: types3_1.Node{
+						Path:      "/rootlink",
+						Overwrite: util.BoolP(true),
+						User: types3_1.NodeUser{
+							ID: util.IntP(1000),
+						},
+						Group: types3_1.NodeGroup{
+							Name: util.StrP("groupname"),
+						},
+					},
+					LinkEmbedded1: types3_1.LinkEmbedded1{
+						Hard:   util.BoolP(false),
+						Target: "/foobar",
+					},
+				},
+			},
+		},
+	}
+
+	config3_1WithNoFSOptionsAndNoLabel = types3_1.Config{
+		Ignition: types3_1.Ignition{
+			Version: "3.1.0",
+			Config: types3_1.IgnitionConfig{
+				Merge: []types3_1.Resource{
+					{
+						Source: util.StrP("https://example.com"),
+						Verification: types3_1.Verification{
+							Hash: &aSha512Hash,
+						},
+					},
+				},
+				Replace: types3_1.Resource{
+					Source: util.StrP("https://example.com"),
+					Verification: types3_1.Verification{
+						Hash: &aSha512Hash,
+					},
+				},
+			},
+			Timeouts: types3_1.Timeouts{
+				HTTPResponseHeaders: util.IntP(5),
+				HTTPTotal:           util.IntP(10),
+			},
+			Security: types3_1.Security{
+				TLS: types3_1.TLS{
+					CertificateAuthorities: []types3_1.Resource{
+						{
+							Source: util.StrP("https://example.com"),
+							Verification: types3_1.Verification{
+								Hash: &aSha512Hash,
+							},
+						},
+					},
+				},
+			},
+			Proxy: types3_1.Proxy{
+				HTTPProxy:  util.StrP("https://proxy.example.net/"),
+				HTTPSProxy: util.StrP("https://secure.proxy.example.net/"),
+				NoProxy: []types3_1.NoProxyItem{
+					"www.example.net",
+					"www.example2.net",
+				},
+			},
+		},
+		Storage: types3_1.Storage{
+			Disks: []types3_1.Disk{
+				{
+					Device:    "/dev/sda",
+					WipeTable: util.BoolP(true),
+					Partitions: []types3_1.Partition{
+						{
+							Label:              util.StrP("var"),
+							Number:             1,
+							SizeMiB:            util.IntP(5000),
+							StartMiB:           util.IntP(2048),
+							TypeGUID:           &aUUID,
+							GUID:               &aUUID,
+							WipePartitionEntry: util.BoolP(true),
+							ShouldExist:        util.BoolP(true),
+						},
+					},
+				},
+			},
+			Raid: []types3_1.Raid{
+				{
+					Name:    "array",
+					Level:   "raid10",
+					Devices: []types3_1.Device{"/dev/sdb", "/dev/sdc"},
+					Spares:  util.IntP(1),
+					Options: []types3_1.RaidOption{"foobar"},
+				},
+			},
+			Filesystems: []types3_1.Filesystem{
+				{
+					Path:           util.StrP("/var"),
+					Device:         "/dev/disk/by-partlabel/var",
+					Format:         util.StrP("xfs"),
+					WipeFilesystem: util.BoolP(true),
+					UUID:           &aUUID,
+				},
+			},
+			Files: []types3_1.File{
+				{
+					Node: types3_1.Node{
+						Path:      "/var/varfile",
+						Overwrite: util.BoolPStrict(false),
+						User: types3_1.NodeUser{
+							ID: util.IntP(1000),
+						},
+						Group: types3_1.NodeGroup{
+							Name: util.StrP("groupname"),
+						},
+					},
+					FileEmbedded1: types3_1.FileEmbedded1{
+						Mode: util.IntP(420),
+						Append: []types3_1.Resource{
+							{
+								Compression: util.StrP("gzip"),
+								Source:      util.StrP("https://example.com"),
+								Verification: types3_1.Verification{
+									Hash: &aSha512Hash,
+								},
+								HTTPHeaders: types3_1.HTTPHeaders{
+									types3_1.HTTPHeader{
+										Name:  "Authorization",
+										Value: util.StrP("Basic YWxhZGRpbjpvcGVuc2VzYW1l"),
+									},
+									types3_1.HTTPHeader{
+										Name:  "User-Agent",
+										Value: util.StrP("Mozilla/5.0 (compatible; MSIE 6.0; Windows NT 5.1)"),
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					Node: types3_1.Node{
+						Path:      "/empty",
+						Overwrite: util.BoolPStrict(false),
+					},
+					FileEmbedded1: types3_1.FileEmbedded1{
+						Mode: util.IntP(420),
+						Contents: types3_1.Resource{
+							Source: util.StrPStrict(""),
+						},
+					},
+				},
+			},
+			Directories: []types3_1.Directory{
+				{
+					Node: types3_1.Node{
+						Path:      "/rootdir",
+						Overwrite: util.BoolP(true),
+						User: types3_1.NodeUser{
+							ID: util.IntP(1000),
+						},
+						Group: types3_1.NodeGroup{
+							Name: util.StrP("groupname"),
+						},
+					},
+					DirectoryEmbedded1: types3_1.DirectoryEmbedded1{
+						Mode: util.IntP(420),
+					},
+				},
+			},
+			Links: []types3_1.Link{
+				{
+					Node: types3_1.Node{
+						Path:      "/rootlink",
+						Overwrite: util.BoolP(true),
+						User: types3_1.NodeUser{
+							ID: util.IntP(1000),
+						},
+						Group: types3_1.NodeGroup{
+							Name: util.StrP("groupname"),
+						},
+					},
+					LinkEmbedded1: types3_1.LinkEmbedded1{
 						Hard:   util.BoolP(false),
 						Target: "/foobar",
 					},
@@ -1763,6 +2449,22 @@ func TestTranslate2_4to3_1(t *testing.T) {
 		t.Fatalf("Failed translation: %v", err)
 	}
 	assert.Equal(t, nonexhaustiveConfig3_1, res)
+}
+
+func TestTranslateDeprecated2_4to3_1(t *testing.T) {
+	res, err := v24tov31.Translate(deprecatedConfig2_4, exhaustiveMap)
+	if err != nil {
+		t.Fatalf("Failed translation: %v", err)
+	}
+	assert.Equal(t, config3_1WithNoFSOptions, res)
+}
+
+func TestTranslateWrongDeprecated2_4to3_1(t *testing.T) {
+	res, err := v24tov31.Translate(wrongDeprecatedConfig2_4, exhaustiveMap)
+	if err != nil {
+		t.Fatalf("Failed translation: %v", err)
+	}
+	assert.Equal(t, config3_1WithNoFSOptionsAndNoLabel, res)
 }
 
 func TestTranslate3_0to2_2(t *testing.T) {


### PR DESCRIPTION
Hi,

In this PR, we add support for `create`  object in the filesystem configuration:
```json
  "storage": {
    "filesystems": [
      {
        "mount": {
          "device": "/dev/disk/by-label/ROOT",
          "format": "btrfs",
          "create": {
            "force": true,
            "options": [
              "--label=ROOT",
              "--uuid=9aa5237a-ab6b-458b-a7e8-f25e2baef1a3"
            ]
          }
        }
      }
    ]
```

`ign-converter` will try to use value from `f.Mount.WipeFilesystem` if this one is `nil` and we have a `f.Mount.Create` struct, we try to parse the options (`label` and `uuid`) and `wipeFilesystem` is conditionally bound to `f.Mount.Create.Force`.

Even if `create` object is deprecated, I feel that supporting into the `ign-converter` will help users to migrate to newer versions of `ignition`. 