### PR TITLE
Bump minimum Go version to 1.18

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,7 +14,7 @@ jobs:
     name: Test build
     strategy:
       matrix:
-        go-version: [1.17.x, 1.18.x, 1.19.x]
+        go-version: [1.18.x, 1.19.x]
     runs-on: ubuntu-latest
     steps:
     - name: Set up Go 1.x

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/coreos/ign-converter
 
-go 1.17
+go 1.18
 
 require (
 	github.com/clarketm/json v1.17.1


### PR DESCRIPTION
Go 1.17 is EOL.