### PR TITLE
v34tov33: fix Tang advertisement check and tests that failed to catch it

### DIFF
--- a/translate/v34tov33/v34tov33.go
+++ b/translate/v34tov33/v34tov33.go
@@ -159,10 +159,8 @@ func checkValue(v reflect.Value) error {
 				return fmt.Errorf("Invalid input config: arn: scheme for s3 is not supported in spec v3.3")
 			}
 		}
-	default:
-		return descend(v)
 	}
-	return nil
+	return descend(v)
 }
 
 func descend(v reflect.Value) error {

--- a/translate/v34tov33/v34tov33.go
+++ b/translate/v34tov33/v34tov33.go
@@ -102,7 +102,7 @@ func Translate(cfg old_types.Config) (types.Config, error) {
 		return types.Config{}, fmt.Errorf("Invalid input config:\n%s", rpt.String())
 	}
 
-	err := recursiveIsOk(reflect.ValueOf(cfg))
+	err := checkValue(reflect.ValueOf(cfg))
 	if err != nil {
 		return types.Config{}, err
 	}
@@ -117,17 +117,15 @@ func Translate(cfg old_types.Config) (types.Config, error) {
 	return res, nil
 }
 
-func recursiveIsOk(v reflect.Value) error {
-	t := v.Type()
-	k := t.Kind()
-	switch {
-	case t == reflect.TypeOf(old_types.Tang{}):
+func checkValue(v reflect.Value) error {
+	switch v.Type() {
+	case reflect.TypeOf(old_types.Tang{}):
 		tang := v.Interface().(old_types.Tang)
 		// 3.3 does not support tang offline provisioning
 		if util.NotEmpty(tang.Advertisement) {
 			return fmt.Errorf("Invalid input config: tang offline provisioning is not supported in spec v3.3")
 		}
-	case t == reflect.TypeOf(old_types.Luks{}):
+	case reflect.TypeOf(old_types.Luks{}):
 		luks := v.Interface().(old_types.Luks)
 		// 3.3 does not support luks discard
 		if util.IsTrue(luks.Discard) {
@@ -137,19 +135,19 @@ func recursiveIsOk(v reflect.Value) error {
 		if len(luks.OpenOptions) > 0 {
 			return fmt.Errorf("Invalid input config: luks openOptions is not supported in spec v3.3")
 		}
-	case t == reflect.TypeOf(old_types.FileEmbedded1{}):
+	case reflect.TypeOf(old_types.FileEmbedded1{}):
 		f := v.Interface().(old_types.FileEmbedded1)
 		// 3.3 does not support special mode bits in files
 		if f.Mode != nil && (*f.Mode&07000) != 0 {
 			return fmt.Errorf("Invalid input config: special mode bits are not supported in spec v3.3")
 		}
-	case t == reflect.TypeOf(old_types.DirectoryEmbedded1{}):
+	case reflect.TypeOf(old_types.DirectoryEmbedded1{}):
 		d := v.Interface().(old_types.DirectoryEmbedded1)
 		// 3.3 does not support special mode bits in directories
 		if d.Mode != nil && (*d.Mode&07000) != 0 {
 			return fmt.Errorf("Invalid input config: special mode bits are not supported in spec v3.3")
 		}
-	case t == reflect.TypeOf(old_types.Resource{}):
+	case reflect.TypeOf(old_types.Resource{}):
 		resource := v.Interface().(old_types.Resource)
 		// 3.3 does not support arn: scheme for s3
 		if util.NotEmpty(resource.Source) {
@@ -161,18 +159,27 @@ func recursiveIsOk(v reflect.Value) error {
 				return fmt.Errorf("Invalid input config: arn: scheme for s3 is not supported in spec v3.3")
 			}
 		}
+	default:
+		return descend(v)
+	}
+	return nil
+}
+
+func descend(v reflect.Value) error {
+	k := v.Type().Kind()
+	switch {
 	case util.IsPrimitive(k):
 		return nil
 	case k == reflect.Struct:
 		for i := 0; i < v.NumField(); i += 1 {
-			err := recursiveIsOk(v.Field(i))
+			err := checkValue(v.Field(i))
 			if err != nil {
 				return err
 			}
 		}
 	case k == reflect.Slice:
 		for i := 0; i < v.Len(); i += 1 {
-			err := recursiveIsOk(v.Index(i))
+			err := checkValue(v.Index(i))
 			if err != nil {
 				return err
 			}
@@ -180,7 +187,7 @@ func recursiveIsOk(v reflect.Value) error {
 	case k == reflect.Ptr:
 		v = v.Elem()
 		if v.IsValid() {
-			return recursiveIsOk(v)
+			return checkValue(v)
 		}
 	}
 	return nil

--- a/translate/v34tov33/v34tov33.go
+++ b/translate/v34tov33/v34tov33.go
@@ -26,11 +26,10 @@ import (
 	"github.com/coreos/ignition/v2/config/validate"
 )
 
-// Copy of github.com/coreos/ignition/config/v3_4/translate/translate.go
+// Copy of github.com/coreos/ignition/v2/config/v3_4/translate/translate.go
 // with the types & old_types imports reversed (the referenced file translates
 // from 3.3 -> 3.4 but as a result only touches fields that are understood by
 // the 3.3 spec).
-
 func translateIgnition(old old_types.Ignition) (ret types.Ignition) {
 	// use a new translator so we don't recurse infinitely
 	translate.NewTranslator().Translate(&old, &ret)

--- a/translate_test.go
+++ b/translate_test.go
@@ -2358,6 +2358,7 @@ func TestTranslate3_4to3_3(t *testing.T) {
 		Storage: types3_4.Storage{
 			Luks: []types3_4.Luks{
 				{
+					Device: util.StrP("/dev/sda"),
 					Clevis: types3_4.Clevis{
 						Tang: []types3_4.Tang{
 							{
@@ -2380,6 +2381,7 @@ func TestTranslate3_4to3_3(t *testing.T) {
 		Storage: types3_4.Storage{
 			Luks: []types3_4.Luks{
 				{
+					Device:  util.StrP("/dev/sda"),
 					Discard: util.BoolP(true),
 				},
 			},
@@ -2394,6 +2396,7 @@ func TestTranslate3_4to3_3(t *testing.T) {
 		Storage: types3_4.Storage{
 			Luks: []types3_4.Luks{
 				{
+					Device:      util.StrP("/dev/sda"),
 					OpenOptions: []types3_4.OpenOption{"foo"},
 				},
 			},
@@ -2453,6 +2456,9 @@ func TestTranslate3_4to3_3(t *testing.T) {
 		Storage: types3_4.Storage{
 			Files: []types3_4.File{
 				{
+					Node: types3_4.Node{
+						Path: "/path",
+					},
 					FileEmbedded1: types3_4.FileEmbedded1{
 						Contents: types3_4.Resource{
 							Source: util.StrP("arn:aws:s3:us-west-1:123456789012:accesspoint/test/object/some/path"),

--- a/translate_test.go
+++ b/translate_test.go
@@ -2411,7 +2411,6 @@ func TestTranslate3_4to3_3(t *testing.T) {
 					Node: types3_4.Node{
 						Path: "/root/file.txt",
 					},
-
 					FileEmbedded1: types3_4.FileEmbedded1{
 						Mode: util.IntP(01777),
 					},
@@ -2419,7 +2418,6 @@ func TestTranslate3_4to3_3(t *testing.T) {
 			},
 		},
 	})
-
 	assert.Error(t, err)
 
 	_, err = v34tov33.Translate(types3_4.Config{
@@ -2446,7 +2444,6 @@ func TestTranslate3_4to3_3(t *testing.T) {
 			},
 		},
 	})
-
 	assert.Error(t, err)
 
 	_, err = v34tov33.Translate(types3_4.Config{


### PR DESCRIPTION
`struct Tang` is a child of `struct Luks`, but the `Luks` checks were returning without walking individual fields, so we were never performing the `Tang` checks.  Fix that, and also fix unrelated validation errors in the test cases that were preventing them from testing the intended behavior.