### PR TITLE
Fix golangci-lint errors for v2.11.3 compatibility

### DIFF
--- a/internal/main.go
+++ b/internal/main.go
@@ -79,15 +79,19 @@ func main() {
 		os.Exit(0)
 	}
 
-	var infile *os.File = os.Stdin
-	var outfile *os.File = os.Stdout
+	var infile = os.Stdin
+	var outfile = os.Stdout
 	if input != "" {
 		var err error
 		infile, err = os.Open(input)
 		if err != nil {
 			fail("failed to open %s: %v", input, err)
 		}
-		defer infile.Close()
+		defer func() {
+			if err := infile.Close(); err != nil {
+				fmt.Fprintf(os.Stderr, "failed to close %s: %v\n", input, err)
+			}
+		}()
 	}
 
 	dataIn, err := io.ReadAll(infile)
@@ -149,7 +153,11 @@ func main() {
 		if err != nil {
 			fail("failed to open %s: %v", output, err)
 		}
-		defer outfile.Close()
+		defer func() {
+			if err := outfile.Close(); err != nil {
+				fmt.Fprintf(os.Stderr, "failed to close %s: %v\n", output, err)
+			}
+		}()
 	}
 
 	if _, err := outfile.Write(dataOut); err != nil {

--- a/translate/v23tov30/v23tov30.go
+++ b/translate/v23tov30/v23tov30.go
@@ -39,7 +39,7 @@ func Check2_3(cfg old.Config, fsMap map[string]string) error {
 	}
 
 	if len(cfg.Networkd.Units) != 0 {
-		return util.UsesNetworkdError
+		return util.ErrUsesNetworkd
 	}
 
 	// check that all filesystems have a path
@@ -142,7 +142,7 @@ func Translate(cfg old.Config, fsMap map[string]string) (types.Config, error) {
 			},
 			Security: types.Security{
 				TLS: types.TLS{
-					CertificateAuthorities: translateCAs(cfg.Ignition.Security.TLS.CertificateAuthorities),
+					CertificateAuthorities: translateCAs(cfg.Ignition.Security.CertificateAuthorities),
 				},
 			},
 			Timeouts: types.Timeouts{

--- a/translate/v24tov31/v24tov31.go
+++ b/translate/v24tov31/v24tov31.go
@@ -35,11 +35,11 @@ func Check2_4(cfg old.Config, fsMap map[string]string) error {
 	rpt := oldValidate.ValidateWithoutSource(reflect.ValueOf(cfg))
 	if rpt.IsFatal() || rpt.IsDeprecated() {
 		// disallow any deprecated fields
-		return fmt.Errorf("Invalid input config:\n%s", rpt.String())
+		return fmt.Errorf("invalid input config:\n%s", rpt.String())
 	}
 
 	if len(cfg.Networkd.Units) != 0 {
-		return util.UsesNetworkdError
+		return util.ErrUsesNetworkd
 	}
 
 	// check that all filesystems have a path
@@ -416,14 +416,14 @@ func translateNode(n old.Node, m map[string]string) types.Node {
 func translateFiles(files []old.File, m map[string]string) (ret []types.File) {
 	for _, f := range files {
 		// 2.x files are overwrite by default
-		if f.Node.Overwrite == nil {
-			f.Node.Overwrite = util.BoolP(true)
+		if f.Overwrite == nil {
+			f.Overwrite = util.BoolP(true)
 		}
 
 		// In spec 3, overwrite must be false if append is true
 		// i.e. spec 2 files with append true must be translated to spec 3 files with overwrite false
-		if f.FileEmbedded1.Append {
-			f.Node.Overwrite = util.BoolPStrict(false)
+		if f.Append {
+			f.Overwrite = util.BoolPStrict(false)
 		}
 
 		file := types.File{
@@ -437,7 +437,7 @@ func translateFiles(files []old.File, m map[string]string) (ret []types.File) {
 			Source:      util.StrPStrict(f.Contents.Source),
 			HTTPHeaders: translateHTTPHeaders(f.Contents.HTTPHeaders),
 		}
-		c.Verification.Hash = f.FileEmbedded1.Contents.Verification.Hash
+		c.Verification.Hash = f.Contents.Verification.Hash
 
 		if f.Append {
 			file.Append = []types.Resource{c}

--- a/translate/v31tov24/v31tov24.go
+++ b/translate/v31tov24/v31tov24.go
@@ -32,18 +32,18 @@ import (
 func Translate(cfg types.Config) (old.Config, error) {
 	rpt := validate.ValidateWithContext(cfg, nil)
 	if rpt.IsFatal() {
-		return old.Config{}, fmt.Errorf("Invalid input config:\n%s", rpt.String())
+		return old.Config{}, fmt.Errorf("invalid input config:\n%s", rpt.String())
 	}
 
 	// Check for potential issues in the spec 3 config
 	for _, m := range cfg.Ignition.Config.Merge {
 		if m.Compression != nil {
-			return old.Config{}, fmt.Errorf("Compression in Ignition.Config.Merge is not supported on 2.4")
+			return old.Config{}, fmt.Errorf("compression in Ignition.Config.Merge is not supported on 2.4")
 		}
 	}
 
 	if cfg.Ignition.Config.Replace.Compression != nil {
-		return old.Config{}, fmt.Errorf("Compression in Ignition.Config.Replace is not supported on 2.4")
+		return old.Config{}, fmt.Errorf("compression in Ignition.Config.Replace is not supported on 2.4")
 	}
 
 	for _, ca := range cfg.Ignition.Security.TLS.CertificateAuthorities {
@@ -374,7 +374,7 @@ func translateFiles(files []types.File, fss []string) (ret []old.File) {
 			file.Node.Overwrite = util.BoolPStrict(false)
 		}
 
-		if f.FileEmbedded1.Contents.Source != nil {
+		if f.Contents.Source != nil {
 			file.FileEmbedded1.Contents = old.FileContents{
 				Compression: util.StrV(f.Contents.Compression),
 				Source:      util.StrV(f.Contents.Source),

--- a/util/util.go
+++ b/util/util.go
@@ -22,8 +22,8 @@ import (
 
 // Error definitions
 
-// UsesNetworkdError is the error for including networkd configs
-var UsesNetworkdError = errors.New("config includes deprecated networkd section - use Files instead")
+// ErrUsesNetworkd is the error for including networkd configs
+var ErrUsesNetworkd = errors.New("config includes deprecated networkd section - use Files instead")
 
 // NoFilesystemError type for when a filesystem is referenced in a config but there's no mapping to where
 // it should be mounted (i.e. `path` in v3+ configs)


### PR DESCRIPTION
Address linting errors that prevent PR #54 (repo templates sync) from merging. These issues were previously undetected by golangci-lint v1.52.2 but are caught by the newer v2.11.3.

Changes:
- internal/main.go: Remove redundant type declarations and check errors in defer statements (errcheck, staticcheck ST1023)
- util/util.go: Rename UsesNetworkdError to ErrUsesNetworkd following Go error naming conventions (staticcheck ST1012)
- translate/*: Lowercase error message strings (staticcheck ST1005)
- translate/*: Remove redundant embedded field selectors (staticcheck QF1008)

All existing tests pass. No functional changes.

Fixes golangci-lint issues found in:
https://github.com/coreos/ign-converter/pull/54/checks