### PR TITLE
translate: allow special mode bits in v34tov33 translation

### DIFF
--- a/translate/v34tov33/v34tov33.go
+++ b/translate/v34tov33/v34tov33.go
@@ -135,18 +135,6 @@ func checkValue(v reflect.Value) error {
 		if len(luks.OpenOptions) > 0 {
 			return fmt.Errorf("invalid input config: luks openOptions is not supported in spec v3.3")
 		}
-	case reflect.TypeOf(old_types.FileEmbedded1{}):
-		f := v.Interface().(old_types.FileEmbedded1)
-		// 3.3 does not support special mode bits in files
-		if f.Mode != nil && (*f.Mode&07000) != 0 {
-			return fmt.Errorf("invalid input config: special mode bits are not supported in spec v3.3")
-		}
-	case reflect.TypeOf(old_types.DirectoryEmbedded1{}):
-		d := v.Interface().(old_types.DirectoryEmbedded1)
-		// 3.3 does not support special mode bits in directories
-		if d.Mode != nil && (*d.Mode&07000) != 0 {
-			return fmt.Errorf("invalid input config: special mode bits are not supported in spec v3.3")
-		}
 	case reflect.TypeOf(old_types.Resource{}):
 		resource := v.Interface().(old_types.Resource)
 		// 3.3 does not support arn: scheme for s3

--- a/translate_test.go
+++ b/translate_test.go
@@ -2828,7 +2828,8 @@ func TestTranslate3_4to3_3(t *testing.T) {
 	})
 	assert.Error(t, err)
 
-	_, err = v34tov33.Translate(types3_4.Config{
+	// Test that special mode bits are correctly masked out during translation
+	res, err = v34tov33.Translate(types3_4.Config{
 		Ignition: types3_4.Ignition{
 			Version: "3.4.0",
 		},
@@ -2845,9 +2846,11 @@ func TestTranslate3_4to3_3(t *testing.T) {
 			},
 		},
 	})
-	assert.Error(t, err)
+	assert.NoError(t, err)
+	// Verify that special mode bits were masked out (01777 -> 0777)
+	assert.Equal(t, util.IntP(0777), res.Storage.Files[0].Mode)
 
-	_, err = v34tov33.Translate(types3_4.Config{
+	res, err = v34tov33.Translate(types3_4.Config{
 		Ignition: types3_4.Ignition{
 			Version: "3.4.0",
 		},
@@ -2871,7 +2874,9 @@ func TestTranslate3_4to3_3(t *testing.T) {
 			},
 		},
 	})
-	assert.Error(t, err)
+	assert.NoError(t, err)
+	// Verify that special mode bits were masked out (01777 -> 0777)
+	assert.Equal(t, util.IntP(0777), res.Storage.Directories[0].Mode)
 
 	_, err = v34tov33.Translate(types3_4.Config{
 		Ignition: types3_4.Ignition{


### PR DESCRIPTION
Previously, the v34tov33 translator would error if special mode bits (setuid/setgid/sticky) were present in file or directory modes. This prevented down-translation of valid v3.4 configs.

The translator already had the correct logic to mask out special mode bits during translation (since v3.3 doesn't support them), but the validation was preventing that code from running.

This fix removes the validation checks and allows the translation to proceed, with special mode bits being masked out as intended.

Fixes coreos/ign-converter#61